### PR TITLE
fix build for LLVM@18 with LLVM libc++ (macos)

### DIFF
--- a/genesis/m68k/cpu_bus.hpp
+++ b/genesis/m68k/cpu_bus.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <array>
 #include <type_traits>
+#include <algorithm>
 
 
 namespace genesis::m68k


### PR DESCRIPTION
std:fill requires `<algorithm>`, otherwise it fails:

```
sergey@Sergeys-MacBook-Air build % make
[  0%] Building CXX object genesis/CMakeFiles/genesis_core.dir/rom.cpp.o 
[  0%] Building CXX object genesis/CMakeFiles/genesis_core.dir/smd/smd.cpp.o In file included from /Users/sergey/atsc/genesis/genesis/smd/smd.cpp:1: 
In file included from /Users/sergey/atsc/genesis/genesis/smd/smd.h:5: 
In file included from /Users/sergey/atsc/genesis/genesis/m68k/cpu.h:4: /Users/sergey/atsc/genesis/genesis/m68k/cpu_bus.hpp:52:8: error: no member named 'fill' in namespace 'std'
   52 |                 std::fill(std::begin(bus_state), std::end(bus_state), false);
      |                 ~~~~~^
1 error generated.
```