### PR TITLE
add macos ci

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,28 @@
+name: MacOS CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install llvm and cmake from homebrew
+      run: brew install llvm cmake
+
+    - name: Build project
+      run: |
+        cmake -G "Unix Makefiles"
+        make -j3
+      env:
+        CC: /opt/homebrew/opt/llvm/bin/clang
+        CXX: /opt/homebrew/opt/llvm/bin/clang++
+
+    - name: Run tests
+      run: ctest


### PR DESCRIPTION
This PR should be accepted after https://github.com/Darrer/genesis/pull/1

Currently, macos apple clang doesn't support C++23 so external llvm should be installed first.

Run log: https://github.com/svlobanov/genesis/actions/runs/9827855693/job/27131063755
