### PR TITLE
remove SDL_RENDERER_ACCELERATED flag in SDL_CreateRenderer() call

### DIFF
--- a/genesis/sdl/plane_display.h
+++ b/genesis/sdl/plane_display.h
@@ -53,7 +53,21 @@ public:
 		m_title = title;
 
 		create_window(title, m_width, m_height);
-		m_renderer = SDL_CreateRenderer(m_window, -1, SDL_RENDERER_ACCELERATED);
+		m_renderer = SDL_CreateRenderer(m_window, -1, 0);
+		SDL_RendererInfo rendererInfo;
+		if(SDL_GetRendererInfo(m_renderer, &rendererInfo) == 0)
+		{
+			std::cout << "Renderer name for window '" << title << "' : " << rendererInfo.name << ". Flags:";
+			std::cout << " SOFTWARE=" << !!(rendererInfo.flags & SDL_RENDERER_SOFTWARE);
+			std::cout << " ACCELERATED=" << !!(rendererInfo.flags & SDL_RENDERER_ACCELERATED);
+			std::cout << " PRESENTVSYNC=" << !!(rendererInfo.flags & SDL_RENDERER_PRESENTVSYNC);
+			std::cout << " TARGETTEXTURE=" << !!(rendererInfo.flags & SDL_RENDERER_TARGETTEXTURE);
+			std::cout << std::endl;
+		}
+		else
+		{
+			std::cerr << "Could not get renderer info! SDL_Error: " << SDL_GetError() << std::endl;
+		}
 		m_texture = create_texture(m_width, m_height);
 	}
 


### PR DESCRIPTION
SDL_RENDERER_ACCELERATED flag blocks running GUI in non-accelerated environment. This patch set flags=0 in SDL_CreateRenderer() call so SDL2 chooses best available driver (e.g. metal on macos, direct3d12 on Windows) when application is executed on normal host. If acceleration is not available (e.g. on vnc, xvfb) then SDL2 chooses software renderer. Software renderer will be useful to run GUI tests in CI.

Automatically choosed renderer driver and renderer flags are displayed in the stdout for troubleshooting purposes.