### PR TITLE
ci: add codeql analyzer

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,54 @@
+name: CodeQL Analysis CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  codeql-analysis:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - CC: "clang"
+            CXX: "clang++"
+          - CC: "gcc"
+            CXX: "g++"
+    permissions:
+      packages: read
+      security-events: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: cpp
+        build-mode: autobuild
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:cpp"
+        output: sarif-results
+        upload: failure-only
+      env:
+        CC: ${{ matrix.CC }}
+        CXX: ${{ matrix.CXX }}
+
+    - name: filter-sarif (exclude third-party related warnings)
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**/_deps/**
+        input: sarif-results/cpp.sarif
+        output: sarif-results/cpp.sarif
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: sarif-results/cpp.sarif


### PR DESCRIPTION
Currently it found only one issue (which looks like more potential than real), but anyway it is better than no analyzers.
```
[genesis/vdp/register_set.h:27](https://github.com/svlobanov/genesis/blob/bcaffa0172176a8f1641aeaac66cc1de8ac2e629/genesis/vdp/register_set.h#L27-L27) 
			&R21, &R22, &R23
		};

		for(std::uint8_t i = 0; i < m_registers.size(); ++i)
Comparison between  of type uint8_t and  of wider type size_type.
```

Not sure, but the results should be here: https://github.com/Darrer/genesis/security/code-scanning?query=pr%3A6+is%3Aopen (maybe it will be available only after merge)
